### PR TITLE
Add simple Magic the Gathering codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# testing
+# Magic the Gathering Codex
+
+This repository contains a small example codex for Magic the Gathering cards.
+
+## Usage
+
+Install Python 3 and run the `codex.py` script:
+
+```bash
+python codex/codex.py list
+python codex/codex.py search Lotus
+```
+
+The card data lives in `codex/cards.json`. You can extend this file with your
+own card entries.

--- a/codex/cards.json
+++ b/codex/cards.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Black Lotus",
+    "type": "Artifact",
+    "mana_cost": "0",
+    "text": "{T}, Sacrifice Black Lotus: Add three mana of any one color.",
+    "set": "LEA",
+    "rarity": "Rare"
+  },
+  {
+    "name": "Lightning Bolt",
+    "type": "Instant",
+    "mana_cost": "R",
+    "text": "Lightning Bolt deals 3 damage to any target.",
+    "set": "M11",
+    "rarity": "Common"
+  },
+  {
+    "name": "Ancestral Recall",
+    "type": "Instant",
+    "mana_cost": "U",
+    "text": "Target player draws three cards.",
+    "set": "LEA",
+    "rarity": "Rare"
+  }
+]

--- a/codex/codex.py
+++ b/codex/codex.py
@@ -1,0 +1,44 @@
+import json
+import argparse
+from pathlib import Path
+
+
+def load_cards(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def list_cards(cards):
+    for card in cards:
+        print(f"{card['name']} - {card['type']} - {card['mana_cost']}")
+
+
+def search_cards(cards, query):
+    query_lower = query.lower()
+    return [c for c in cards if query_lower in c['name'].lower()]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Magic the Gathering Codex')
+    parser.add_argument('action', choices=['list', 'search'])
+    parser.add_argument('query', nargs='?', help='Name to search for')
+    parser.add_argument('--data', default=Path(__file__).with_name('cards.json'))
+    args = parser.parse_args()
+
+    cards = load_cards(args.data)
+
+    if args.action == 'list':
+        list_cards(cards)
+    elif args.action == 'search':
+        if not args.query:
+            parser.error('search requires a query string')
+        matches = search_cards(cards, args.query)
+        if matches:
+            for card in matches:
+                print(json.dumps(card, indent=2))
+        else:
+            print('No matches found')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `codex` directory with small card dataset and a CLI script to search or list cards
- document usage of the codex in README

## Testing
- `pytest -q`
- `python codex/codex.py list`
- `python codex/codex.py search Lotus`


------
https://chatgpt.com/codex/tasks/task_e_683f548b12c0832ebfe968804776420a