### PR TITLE
Add Shadow of the Sun narrative-simulation game document

### DIFF
--- a/shadow-of-the-sun.md
+++ b/shadow-of-the-sun.md
@@ -1,0 +1,609 @@
+# Shadow of the Sun
+
+### A complex, playable narrative-simulation about why technology is not ethically neutral
+
+> **Theme:** Technology is never “just a tool.” It carries the priorities, exclusions, defaults, incentives, and fantasies of the institutions that build it—and then it reshapes the world back.
+
+This is an **Oppenheimer-inspired** experience: a wartime scientific project racing toward a world-altering “device.” You will feel the tension between discovery, patriotism, fear, ambition, bureaucracy, secrecy, and conscience—without turning the game into a quiz.
+
+**Important safety note:** This game does **not** teach real-world weapon construction. “The Device” and its research are abstracted.
+
+---
+
+## What you need
+
+* 2–6 players (solo is supported) + 1 facilitator **or** GMless mode
+* Paper, pens
+* 2 six-sided dice (2d6) **or** a dice roller
+* Tokens/coins (about 25)
+* Timer (optional)
+
+**Play time:** 2–4 hours for a one-shot, or 2–5 sessions for a campaign.
+
+---
+
+## Core concept: Embedded Values (the point of the game)
+
+Every time you “make progress,” you also **embed values** into the technology and the institution around it.
+
+Those embedded values become **mechanical facts** later: they unlock options, close options, shift outcomes automatically, and haunt you.
+
+You will end the game with two products:
+
+1. **A Device** (or a non-device outcome) with a visible “value-script.”
+2. **A record of consequences** you can’t fully control.
+
+---
+
+# 1) Setting
+
+### 194X, The Republic of Helion
+
+A total war grinds on. Intelligence warns an enemy alliance may be pursuing a “Sun-Device.” Helion forms a secret program in a remote desert basin.
+
+You are the **Scientific Director** (or a council, if playing group mode). Your mandate is simple and impossible:
+
+* **Deliver a decisive capability.**
+* **Maintain secrecy.**
+* **Prevent internal collapse.**
+* **Live with what follows.**
+
+---
+
+# 2) Roles
+
+Choose **one** role per player. If solo, you play the Director plus one “Inner Voice.”
+
+## A) Scientific Director (required)
+
+You decide priorities, sign memos, meet generals, and absorb blame.
+
+* **Strength:** Steering complex systems.
+* **Weakness:** You become the institution.
+
+## B) Security Chief
+
+Controls information, background checks, surveillance, compartmentalization.
+
+* **Strength:** Prevents leaks.
+* **Weakness:** Creates paranoia; crushes trust.
+
+## C) Operations & Logistics
+
+Procurement, labor, housing, toxic waste, schedules.
+
+* **Strength:** Makes the impossible work.
+* **Weakness:** Human costs become “throughput.”
+
+## D) Ethics / Medical Lead
+
+Human subjects, worker safety, downstream policy, moral injury.
+
+* **Strength:** Reduces harm.
+* **Weakness:** Often overruled; becomes scapegoat.
+
+## E) Political Liaison
+
+Budget, alliances, oversight committees, press handling.
+
+* **Strength:** Keeps funding and cover.
+* **Weakness:** Turns truth into strategy.
+
+## F) External Witness (Journalist / Union Organizer / Local Leader)
+
+Not “inside” the program; you pressure it.
+
+* **Strength:** Reality-check.
+* **Weakness:** Limited access; vulnerable to intimidation.
+
+---
+
+# 3) The Board (trackers)
+
+Create these tracks on paper.
+
+### PROJECT TRACKS
+
+* **Progress (0–12):** How close the program is to a deliverable.
+* **Secrecy (0–10):** Ability to contain info.
+* **Workforce (0–10):** Capacity, recruitment, retention.
+* **Stability (0–10):** Internal cohesion: morale, conflict, burnout.
+* **Budget (0–10):** Political capital and resources.
+
+### WORLD TRACKS
+
+* **War Pressure (0–10):** Increases over time; triggers coercive oversight.
+* **Public Trust (-5 to +5):** The nation’s confidence (even if secret leaks shape rumor).
+* **Rival Progress (0–12):** Your best estimate of the enemy’s timeline (uncertain).
+
+### PERSONAL TRACKS (Director)
+
+* **Integrity (0–10):** Ability to act consistently with your values.
+* **Moral Injury (0–10):** Accumulated unresolved harm.
+* **Legacy (0–10):** How history will interpret you (not under your control).
+
+---
+
+# 4) Value-Script Tokens (the heart)
+
+Write these **Value Tokens** on slips or just list them and mark counts.
+
+**Speed** • **Secrecy** • **Control** • **Deterrence** • **Care** • **Transparency** • **Equity** • **Accountability** • **Prestige** • **Sacrifice**
+
+You will **embed** tokens into:
+
+* **The Device** (what it *tends* to be used for)
+* **The Institution** (what your program *becomes*)
+
+### How embedding works
+
+At certain moments, you must choose **2 tokens** to embed. Each token immediately alters tracks and permanently changes what options exist later.
+
+**Example:** If you embed **Secrecy** into the Institution early, later you may *not* be able to build credible civilian oversight without major cost.
+
+---
+
+# 5) Setup
+
+1. Set all tracks:
+
+* Progress 0
+* Secrecy 5
+* Workforce 5
+* Stability 5
+* Budget 5
+* War Pressure 3
+* Public Trust 0
+* Rival Progress 2
+* Director Integrity 7
+* Moral Injury 0
+* Legacy 3
+
+2. Choose a **Starting Doctrine** (circle one):
+
+* **End the war fast** (start War Pressure +1, Integrity -1)
+* **Prevent catastrophe** (start Integrity +1, Budget -1)
+* **Protect the republic** (start Secrecy +1, Public Trust -1)
+* **Prove scientific greatness** (start Progress +1, Moral Injury +1)
+
+3. Choose your **Relationships** (each player writes two):
+
+* Someone you admire in the project
+* Someone you distrust
+* Someone you can’t afford to lose
+* Someone who can ruin you
+
+4. Create the **Three Factions** (write a name for each):
+
+* Military Command
+* Scientific Council
+* Civilian Government
+  Each faction starts at **Influence 2** (0–5). Influence changes who can force decisions.
+
+---
+
+# 6) Game structure
+
+The game is divided into **Acts**. Each Act has multiple **Turns** (each turn = a month).
+
+### Each Turn (Month)
+
+1. **War Pressure rises** (+1 every 2 turns; +1 extra if Rival Progress is ahead of you by 3+)
+2. **Choose Actions** (each inside-role chooses 1 action; Director chooses 2)
+3. **Resolve rolls** (2d6 + modifiers)
+4. **Draw an Event** (from the Event Deck below)
+5. **Check thresholds** (crises, hearings, breakthroughs)
+6. **Scene**: play 5–10 minutes of roleplay triggered by what happened
+
+---
+
+# 7) Actions (no quizzes, only consequential choices)
+
+For each action, roll **2d6**.
+
+* **10+** success with benefit
+* **7–9** success with complication (choose 1 complication)
+* **6-** failure; the facilitator escalates and you mark a cost
+
+**Modifiers:**
+
+* If an action aligns with your **embedded tokens**, +1
+* If it conflicts with embedded tokens, -1
+* If Stability ≤3, -1 to all internal actions
+* If Secrecy ≤3, -1 to information-control actions
+
+## Director actions (choose 2 per turn)
+
+### 1) Accelerate Research
+
+On 10+: Progress +2. Choose 1: Workforce -1 or Stability -1.
+On 7–9: Progress +1, and embed **Speed** into Institution OR Device.
+On 6-: Progress +0, Stability -1, Moral Injury +1.
+
+### 2) Reframe the Mission (propaganda / narrative)
+
+On 10+: Public Trust +1, Budget +1.
+On 7–9: Public Trust +1, but embed **Prestige** or **Sacrifice** into Institution.
+On 6-: Public Trust -1, Secrecy -1.
+
+### 3) Build Oversight (ethics board, civilian review, union voice)
+
+On 10+: Accountability token becomes available (if not already). Stability +1, Moral Injury -1.
+On 7–9: Choose one: (a) Accountability +1 but Secrecy -1, or (b) Secrecy +1 but Integrity -1.
+On 6-: Oversight collapses; Public Trust -1; embed **Control** into Institution.
+
+### 4) Negotiate with Command
+
+On 10+: Budget +1 and choose 1: War Pressure -1 or Secrecy +1.
+On 7–9: Gain one, lose one (your choice).
+On 6-: Command issues a Direct Order (see Direct Orders).
+
+### 5) Protect People (workforce safety, housing, compensation)
+
+On 10+: Workforce +1, Stability +1.
+On 7–9: Choose 1: Workforce +1 OR Stability +1.
+On 6-: Accident. Moral Injury +2; Secrecy -1.
+
+### 6) Speak the Unspeakable (private confession / dissent)
+
+On 10+: Integrity +1; remove 1 embedded token from Institution (not Device).
+On 7–9: Integrity +1 but Secrecy -1.
+On 6-: You are flagged as a risk; Security gains Influence +1.
+
+## Security Chief actions
+
+* **Compartmentalize** (boost Secrecy; harm Stability)
+* **Counterintelligence** (reduce leaks; may incriminate innocents)
+* **Purge** (remove a “threat”; severe morale cost)
+
+## Operations actions
+
+* **Scale Workforce** (recruit; may exploit)
+* **Stabilize Supply Chains** (Budget to Workforce)
+* **Manage Waste** (reduce future harm; slows Progress)
+
+## Ethics/Medical actions
+
+* **Safety Protocols** (reduce accidents; slows Progress)
+* **Consent & Compensation** (increase Public Trust; risk Secrecy)
+* **Downstream Planning** (affects endings)
+
+## Political Liaison actions
+
+* **Secure Funding** (Budget)
+* **Handle Oversight** (Public Trust vs Secrecy)
+* **Build Coalition** (reduce War Pressure; costs Budget)
+
+## External Witness actions
+
+* **Investigate** (can reveal harm)
+* **Organize** (can improve Equity/Accountability)
+* **Expose** (hurts Secrecy; boosts Public Trust sometimes)
+
+(Full action list in Appendix A.)
+
+---
+
+# 8) The Research Tree (abstract, but consequential)
+
+The program progresses through **Milestones**. When you cross each Milestone, you must **embed 2 Value Tokens** into either **Device** or **Institution**.
+
+Milestones (Progress thresholds):
+
+* **3 — Feasibility**
+* **6 — Prototype Path Chosen**
+* **9 — Demonstration Capability**
+* **12 — Deliverable**
+
+### Prototype Paths (choose at Progress ≥6)
+
+Pick one path; it shapes what “success” means.
+
+**Path I: The Hammer**
+
+* Quick deliverable, maximal destructive potential.
+* +1 to Accelerate Research rolls.
+* Every time you gain Progress, also roll 1d6: on 1–2 Moral Injury +1.
+
+**Path II: The Shield**
+
+* Defensive/containment capability, harder to weaponize.
+* Progress gains are slower (-1 on Accelerate outcomes), but Public Trust +1 whenever you build oversight.
+
+**Path III: The Signal**
+
+* Demonstration/deterrence without immediate deployment.
+* Rival Progress increases faster (+1 every 2 turns) unless you embed Deterrence.
+
+**Path IV: The Archive**
+
+* You intentionally fragment the project into knowledge rather than a device.
+* Progress max is 9; you can “win” through political settlement endings.
+
+---
+
+# 9) Direct Orders (institutional coercion)
+
+Whenever Command wins Influence or you roll a 6- on **Negotiate with Command**, draw or choose an Order:
+
+1. **Priority Shift:** Next turn, Director must take Accelerate Research.
+2. **Compartmentalization:** Secrecy +2, Stability -2.
+3. **Silence:** External Witness cannot act next turn.
+4. **Human Cost:** Progress +1 now; Moral Injury +2.
+5. **Replace You:** Integrity -2 OR resign (trigger Hearing Act).
+
+Direct Orders teach: institutions *reconfigure ethics* through authority.
+
+---
+
+# 10) The Event Deck (30 events)
+
+You can cut these into cards or roll 1d30 (or 1d6 + 1d6 table; see Appendix B).
+
+Each event has: **Trigger** (if any) and **Choice** (never neutral).
+
+### Sample events (full deck below)
+
+**E1 — The Accident**
+Trigger: Workforce ≥7 OR Progress ≥5.
+
+* Choose: (a) Cover it up (Secrecy +1, Moral Injury +2, Public Trust -1), or (b) Report it (Accountability +1, Secrecy -1, Stability +1).
+
+**E4 — The Philosopher Visits**
+
+* A famous thinker asks: “What do you think you’re building?”
+* If you answer as *means*, embed Speed/Control.
+* If you answer as *ends*, embed Accountability/Care.
+* In either case, Integrity shifts accordingly.
+
+**E9 — The Petition**
+
+* Staff demand oversight. If you refuse: Stability -2, Secrecy +1.
+* If you accept: Accountability +1, Secrecy -1, Budget -1.
+
+**E13 — Rival Rumor**
+
+* Rival Progress +1 (always). If you tighten secrecy: Secrecy +2, Stability -1.
+* If you go transparent: Public Trust +1, Secrecy -2.
+
+**E21 — The Test Site**
+
+* Choose where demonstration happens:
+
+  * Remote desert (Secrecy +1, Equity -1)
+  * Indigenous land (Progress +1, Moral Injury +2)
+  * Coastal waters (Public Trust -1, Future Fallout +1)
+  * International supervision (Accountability +2, War Pressure +1)
+
+**E30 — The Hearing**
+Trigger: Public Trust ≤-2 OR Secrecy ≤2 OR you resign.
+
+* A tribunal asks not “what happened?” but “who you are.”
+* Your embedded tokens shape the verdict.
+
+---
+
+# 11) Fallout: The world pushes back
+
+Create a hidden track called **Fallout (0–12)**. Only the facilitator (or the table collectively in GMless) tracks it.
+
+Fallout increases when you:
+
+* embed **Speed, Secrecy, Control, Sacrifice** into the Device (often)
+* cover up accidents
+* accept Human Cost orders
+* deploy without oversight
+
+Fallout decreases when you:
+
+* embed **Care, Equity, Accountability, Transparency** into Institution
+* compensate communities
+* plan downstream safeguards
+
+At the end, Fallout determines what kind of world your technology makes likely.
+
+---
+
+# 12) Scenes (the Oppenheimer-inspired heart)
+
+Every turn ends with a short scene. Pick one prompt:
+
+* **The Blackboard:** a breakthrough is also a moral concession.
+* **The Party:** laughter in a fenced city.
+* **The Letter:** a spouse/friend writes something you can’t answer.
+* **The Briefing:** generals translate your work into targets.
+* **The Hospital:** someone coughs dust.
+* **The Desert Night:** you imagine the light.
+* **The Interrogation:** loyalty becomes a weapon.
+
+**Rule:** In every scene, someone must say a line that reveals a value they’re willing to trade.
+
+---
+
+# 13) Endgame (how you “win,” and why it never feels like winning)
+
+When Progress hits **12**, or when you trigger a political settlement (Archive path), you enter Endgame.
+
+### Choose the Endgame Frame (based on tokens)
+
+* If Device has **Deterrence + Control**: “Managed Threat” ending table
+* If Device has **Speed + Sacrifice**: “Rushed Catastrophe” table
+* If Institution has **Accountability + Transparency**: “Public Reckoning” table
+* If Institution has **Prestige + Secrecy**: “Myth & Scapegoat” table
+
+Then roll 2d6 and apply modifiers:
+
+* Fallout ≥8: -2
+* Public Trust ≥2: +1
+* Rival Progress ≥10: -1
+* Accountability token present: +1
+
+Endings are not binary; they are *histories*.
+
+---
+
+# 14) The Debrief (the learning lands here)
+
+After the ending, answer:
+
+1. **What values did you embed into the Device?** Where did they come from?
+2. **Which harms were “externalities” in your system?** Who paid them?
+3. **When did the institution start making choices for you?**
+4. **Which options disappeared over time?** (path dependence)
+5. **Who will inherit the technology?** What defaults will they assume?
+
+Optional: Each player writes a one-paragraph “History textbook excerpt” about the program, then trade excerpts and notice contradictions.
+
+---
+
+# 15) Quickstart (play in 15 minutes)
+
+1. Set tracks to defaults.
+2. Choose Starting Doctrine.
+3. Start at Act I. Take 3 turns.
+4. At Progress 3, embed 2 tokens.
+5. Draw 1 event per turn.
+6. Do a scene per turn.
+
+If you’re playing this **with ChatGPT as facilitator**, paste:
+
+* Your current track values
+* Your chosen actions for the turn
+* Any embedded tokens so far
+  And I will resolve rolls and events.
+
+---
+
+# ACTS
+
+## Act I — The City in the Desert (Turns 1–3)
+
+**Pressure:** recruitment, secrecy, building a culture.
+
+**Act I crisis threshold:** If Stability ≤3, trigger **E9 Petition** immediately.
+
+## Act II — Breakthroughs & Bargains (Turns 4–7)
+
+**Pressure:** progress accelerates; accidents become likely.
+
+**Act II crisis threshold:** If Workforce ≥8 and Safety not embedded, trigger **E1 Accident**.
+
+## Act III — The Device Has a Politics (Turns 8–10)
+
+**Pressure:** generals demand deliverables; your words become orders.
+
+**Act III threshold:** At Progress ≥9, choose: **Demonstrate**, **Delay**, or **Fragment**.
+
+## Act IV — The Hearing / The World After (Endgame)
+
+You do not control the story that gets told about you.
+
+---
+
+# APPENDIX A — Full action list (condensed)
+
+(Use these as building blocks. Each role picks 1 per turn; Director picks 2.)
+
+### Security
+
+1. **Compartmentalize**: 10+ Secrecy +2; 7–9 Secrecy +1, Stability -1; 6- leak anyway.
+2. **Surveil**: 10+ remove “leak” threat; 7–9 remove threat but Integrity -1; 6- false accusation.
+3. **Purge**: Secrecy +2, Stability -2, Public Trust -1.
+
+### Operations
+
+1. **Recruit**: Workforce +1; if you used coercion, Integrity -1.
+2. **Optimize**: Progress +1; Stability -1.
+3. **Waste Management**: Fallout -1; Progress -1 (this turn).
+
+### Ethics/Medical
+
+1. **Safety Protocols**: reduce chance of E1; Progress -1 (this turn) but Stability +1.
+2. **Consent & Compensation**: Public Trust +1; Budget -1.
+3. **Downstream Safeguards**: place 1 “Safeguard” marker (affects endings).
+
+### Political Liaison
+
+1. **Secure Funding**: Budget +1; if Public Trust <0 then Secrecy +1.
+2. **Handle Oversight**: choose: Public Trust +1 / Secrecy -1 OR Secrecy +1 / Integrity -1.
+3. **Coalition**: War Pressure -1; Budget -1.
+
+### External Witness
+
+1. **Investigate**: on 10+ reveal a harm (Public Trust +1); on 7–9 reveal but Secrecy -1.
+2. **Organize**: Stability +1 if Equity present; else conflict.
+3. **Expose**: Secrecy -2; Public Trust +2 if evidence exists; else Public Trust -1.
+
+---
+
+# APPENDIX B — Event Deck (full list)
+
+Use 1d30, or roll 2d6 twice (first die = tens, second = ones).
+
+E1 Accident
+E2 Breakthrough at a Cost
+E3 Missing Materials
+E4 Philosopher Visits
+E5 Loyalty Interview
+E6 Strike Rumor
+E7 Family Crisis
+E8 Sudden Funding
+E9 Petition
+E10 Spy Panic
+E11 Rival Rumor
+E12 Night Test (false alarm)
+E13 Local Community Complaint
+E14 Classified Memo (changed goalposts)
+E15 Lab Fire
+E16 Contaminated Water
+E17 International Ally Requests Access
+E18 Scientist Threatens to Quit
+E19 The General’s Demonstration (targets)
+E20 Press Leak
+E21 Test Site Decision
+E22 Medical Experiment Temptation (refuse/allow)
+E23 Mathematical Proof (what you can’t un-know)
+E24 Sabotage or Safety?
+E25 The Protest
+E26 The Promotion
+E27 The Letter from the Front
+E28 The Coup Attempt (institutional takeover)
+E29 Armistice Offer
+E30 The Hearing
+
+(For each event, the facilitator should ask: “What does the technology *assume* about people here?” and “Who becomes legible/illegible?”)
+
+---
+
+# OPTIONAL MODULES (for maximum complexity)
+
+## Module 1 — “Scripts” (automatic behavior)
+
+When a token is embedded into the **Device**, write a “script sentence.”
+Example: **Control** → “The Device assumes a centralized operator.”
+Later, if a choice contradicts a script, it costs +1 Moral Injury or -1 Integrity.
+
+## Module 2 — Uncertainty of Rival Progress
+
+Rival Progress is not known. Every 2 turns, roll 1d6:
+
+* 1–2: Rival Progress +0 (your intel was wrong)
+* 3–4: Rival Progress +1
+* 5–6: Rival Progress +2
+  If you embedded **Secrecy**, add +1 to the roll (paranoia inflates threat).
+
+## Module 3 — Social Network (who influences you)
+
+Create 6 named NPCs with stances. Each turn, one NPC changes stance based on embedded tokens (showing values rewire social relations).
+
+---
+
+# PLAYBOOK: Why technology is not ethically neutral (baked into mechanics)
+
+* **Embedded tokens** represent values that become defaults.
+* **Direct Orders** show institutions enforce ethics through power.
+* **Path dependence** is created by permanent token constraints.
+* **Externalities** appear as Fallout.
+* **Narrative control** is a resource (Public Trust) with tradeoffs.
+
+---


### PR DESCRIPTION
### Motivation

- Add a standalone, playable design document for a tabletop narrative-simulation titled “Shadow of the Sun” that explores how technologies embed institutional values. 
- Provide clear, portable rules, roles, trackers, events, and optional modules so groups (or solo players) can run the game without additional materials. 

### Description

- Add `shadow-of-the-sun.md`, a 600+ line Markdown file containing the full game text including setup, roles, project/world/personal tracks, value-token embedding mechanics, actions, milestones, event deck, direct orders, endgame framing, scenes, and debrief prompts. 
- Include a Quickstart, optional complexity modules, and guidance for running the game with ChatGPT as facilitator. 
- Structure the doc so tokens and mechanics explicitly model path-dependence, externalities (Fallout), and institutional power in gameplay. 

### Testing

- This is a documentation-only addition and no automated tests were executed. 
- No code or runtime behavior was changed, so existing test suites (if any) were not applicable to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696934a69dbc832e957acf3289a97c41)